### PR TITLE
keep reactive computations synchronous with the render phase

### DIFF
--- a/packages/react-meteor-data/README.md
+++ b/packages/react-meteor-data/README.md
@@ -22,7 +22,7 @@ This package provides two ways to use Tracker reactive data in your React compon
 - a hook: `useTracker` (v2 only, requires React `^16.8`)
 - a higher-order component (HOC): `withTracker` (v1 and v2).
 
-The `useTracker` hook, introduced in version 2.0.0, is slightly more straightforward to use (lets you access reactive data sources directly within your componenent, rather than adding them from an external wrapper), and slightly more performant (avoids adding wrapper layers in the React tree). But, like all React hooks, it can only be used in function components, not in class components.  
+The `useTracker` hook, introduced in version 2.0.0, is slightly more straightforward to use (lets you access reactive data sources directly within your componenent, rather than adding them from an external wrapper), and slightly more performant (avoids adding wrapper layers in the React tree). But, like all React hooks, it can only be used in function components, not in class components.
 The `withTracker` HOC can be used with all components, function or class.
 
 It is not necessary to rewrite existing applications to use the `useTracker` hook instead of the existing `withTracker` HOC. But for new components, it is suggested to prefer the `useTracker` hook when dealing with function components.
@@ -33,8 +33,8 @@ You can use the `useTracker` hook to get the value of a Tracker reactive functio
 
 Arguments:
 - `reactiveFn`: a Tracker reactive function (with no parameters)
-- `deps`: an array of "dependencies" of the reactive function, i.e. the list of values that, when changed, need to stop the current Tracker computation and start a new one - for example, the value of a prop used in a subscription or a Minimongo query; see example below. This array typically includes all variables from the outer scope "captured" in the closure passed as the 1st argument. This is very similar to how the `deps` argument for [React's built-in `useEffect`, `useCallback` or `useMemo` hooks](https://reactjs.org/docs/hooks-reference.html) work.  
-If omitted, it defaults to `[]` (no dependency), and the Tracker computation will run unchanged until the component is unmounted.
+- `deps`: an array of "dependencies" of the reactive function, i.e. the list of values that, when changed, need to stop the current Tracker computation and start a new one - for example, the value of a prop used in a subscription or a Minimongo query; see example below. This array typically includes all variables from the outer scope "captured" in the closure passed as the 1st argument. This is very similar to how the `deps` argument for [React's built-in `useEffect`, `useCallback` or `useMemo` hooks](https://reactjs.org/docs/hooks-reference.html) work.
+If omitted, the Tracker computation will be recreated on every call.
 
 ```js
 import { useTracker } from 'meteor/react-meteor-data';

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -43,7 +43,12 @@ function is(x, y) {
 // used to replicate dep change behavior and stay consistent
 // with React.useEffect()
 function areHookInputsEqual(nextDeps, prevDeps) {
-  if (!nextDeps || !prevDeps) {
+  if (prevDeps === null || prevDeps === undefined) {
+    return false;
+  }
+
+  // checking prevDeps is unnecessary as prevDeps is always the last version of nextDeps
+  if (!Array.isArray(nextDeps)) {
     return false;
   }
 
@@ -100,10 +105,10 @@ function useTracker(reactiveFn, deps) {
           trackerData.current = data;
         } else {
           // makes sure that shallowEqualArray returns false
-          // which is always the case when prev or nextDeps are not set
+          // which is always the case when prevDeps is null
           previousDeps.current = null;
           // Stop this computation instead of using the re-run.
-          // We use a brand-new autorun for each call to getMeteorData
+          // We use a brand-new autorun for each call
           // to capture dependencies on any reactive data sources that
           // are accessed.  The reason we can't use a single autorun
           // for the lifetime of the component is that Tracker only
@@ -111,9 +116,9 @@ function useTracker(reactiveFn, deps) {
           // re-call the reactive function synchronously whenever we want, e.g.
           // from next render.
           c.stop();
-          // use Math.random() to trigger a state change to enforce a re-render
-          // Calling forceUpdate() triggers componentWillUpdate which
-          // calls the reactive function and re-renders the component.
+          // use a uniqueCounter to trigger a state change to enforce a re-render
+          // which calls the reactive function and re-renders the component with
+          // new data from the reactive function.
           forceUpdate(++uniqueCounter);
         }
       })

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -114,11 +114,13 @@ function useTracker(reactiveFn, deps) {
           // Additional cycles will follow the normal computation behavior.
           runReactiveFn();
         } else {
-          // Only run reactiveFn if the hooks have not change, or are not falsy.
-          if (areHookInputsEqual(deps, refs.previousDeps)) {
+          // Only run reactiveFn if the deps or are not falsy.
+          if (!deps || !refs.previousDeps) {
+            // Dispose early, if refs are falsy - we'll rebuild and run on the next render.
+            dispose();
+          } else {
             runReactiveFn();
           }
-          // If deps have changed or are falsy, let the reactiveFn run on next render.
           // use a uniqueCounter to trigger a state change to force a re-render
           forceUpdate(++uniqueCounter);
         }

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -43,11 +43,10 @@ function is(x, y) {
 // used to replicate dep change behavior and stay consistent
 // with React.useEffect()
 function areHookInputsEqual(nextDeps, prevDeps) {
-  if (prevDeps === null || prevDeps === undefined) {
+  if (prevDeps === null || prevDeps === undefined || !Array.isArray(prevDeps)) {
     return false;
   }
 
-  // checking prevDeps is unnecessary as prevDeps is always the last version of nextDeps
   if (!Array.isArray(nextDeps)) {
     if (Meteor.isDevelopment) {
       // Use React.warn() if available (should ship in React 16.9).

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -63,12 +63,6 @@ function areHookInputsEqual(nextDeps, prevDeps) {
 }
 
 function useTracker(reactiveFn, deps) {
-  // When rendering on the server, we don't want to use the Tracker.
-  // We only do the first rendering on the server so we can get the data right away
-  if (Meteor.isServer) {
-    return reactiveFn();
-  }
-
   const previousDeps = useRef();
   const computation = useRef();
   const trackerData = useRef();

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -62,6 +62,7 @@ function areHookInputsEqual(nextDeps, prevDeps) {
   return true;
 }
 
+let uniqueCounter = 0;
 function useTracker(reactiveFn, deps) {
   const previousDeps = useRef();
   const computation = useRef();
@@ -113,7 +114,7 @@ function useTracker(reactiveFn, deps) {
           // use Math.random() to trigger a state change to enforce a re-render
           // Calling forceUpdate() triggers componentWillUpdate which
           // calls the reactive function and re-renders the component.
-          forceUpdate(Math.random());
+          forceUpdate(++uniqueCounter);
         }
       })
     ));

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -134,7 +134,20 @@ function useTracker(reactiveFn, deps) {
   }
 
   // stop the computation on unmount only
-  useEffect(() => dispose, []);
+  useEffect(() => {
+    if (Meteor.isDevelopment
+      && deps !== null && deps !== undefined
+      && !Array.isArray(deps)) {
+      // Use React.warn() if available (should ship in React 16.9).
+      const warn = React.warn || console.warn.bind(console);
+      warn(
+        'Warning: useTracker expected an initial dependency value of '
+        + `type array but got type of ${typeof deps} instead.`
+      );
+    }
+
+    return dispose;
+  }, []);
 
   return trackerData.current;
 }

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -49,6 +49,14 @@ function areHookInputsEqual(nextDeps, prevDeps) {
 
   // checking prevDeps is unnecessary as prevDeps is always the last version of nextDeps
   if (!Array.isArray(nextDeps)) {
+    if (Meteor.isDevelopment) {
+      // Use React.warn() if available (should ship in React 16.9).
+      const warn = React.warn || console.warn.bind(console);
+      warn(
+        'Warning: useTracker expected an dependency value of '
+        + `type array but got type of ${typeof nextDeps} instead.`
+      );
+    }
     return false;
   }
 
@@ -68,6 +76,7 @@ function areHookInputsEqual(nextDeps, prevDeps) {
 }
 
 let uniqueCounter = 0;
+
 function useTracker(reactiveFn, deps) {
   const previousDeps = useRef();
   const computation = useRef();

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -104,8 +104,9 @@ function useTracker(reactiveFn, deps) {
           previousDeps.current = deps;
           trackerData.current = data;
         } else {
-          // makes sure that shallowEqualArray returns false on next render
-          previousDeps.current = Math.random();
+          // makes sure that shallowEqualArray returns false
+          // which is always the case when prev or nextDeps are not set
+          previousDeps.current = null;
           // Stop this computation instead of using the re-run.
           // We use a brand-new autorun for each call to getMeteorData
           // to capture dependencies on any reactive data sources that

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -74,16 +74,14 @@ function areHookInputsEqual(nextDeps, prevDeps) {
 let uniqueCounter = 0;
 
 function useTracker(reactiveFn, deps) {
-  const previousDeps = useRef();
-  const computation = useRef();
-  const trackerData = useRef();
+  const { current: refs } = useRef({});
 
   const [, forceUpdate] = useState();
 
   const dispose = () => {
-    if (computation.current) {
-      computation.current.stop();
-      computation.current = null;
+    if (refs.computation) {
+      refs.computation.stop();
+      refs.computation = null;
     }
   };
 
@@ -91,7 +89,7 @@ function useTracker(reactiveFn, deps) {
   // in order to support render calls with synchronous data from the reactive computation
   // if prevDeps or deps are not set areHookInputsEqual always returns false
   // and the reactive functions is always called
-  if (!areHookInputsEqual(deps, previousDeps.current)) {
+  if (!areHookInputsEqual(deps, refs.previousDeps)) {
     // if we are re-creating the computation, we need to stop the old one.
     dispose();
 
@@ -100,17 +98,17 @@ function useTracker(reactiveFn, deps) {
     // In that case, we want to opt out of the normal behavior of nested
     // Computations, where if the outer one is invalidated or stopped,
     // it stops the inner one.
-    computation.current = Tracker.nonreactive(() => (
+    refs.computation = Tracker.nonreactive(() => (
       Tracker.autorun((c) => {
         // This will capture data synchronously on first run (and after deps change).
         // Additional cycles will follow the normal computation behavior.
         const data = reactiveFn();
         if (Meteor.isDevelopment) checkCursor(data);
-        trackerData.current = data;
+        refs.trackerData = data;
 
         if (c.firstRun) {
           // store the deps for comparison on next render
-          previousDeps.current = deps;
+          refs.previousDeps = deps;
         } else {
           // use a uniqueCounter to trigger a state change to force a re-render
           forceUpdate(++uniqueCounter);
@@ -133,7 +131,7 @@ function useTracker(reactiveFn, deps) {
     return dispose;
   }, []);
 
-  return trackerData.current;
+  return refs.trackerData;
 }
 
 // When rendering on the server, we don't want to use the Tracker.

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -83,8 +83,9 @@ function useTracker(reactiveFn, deps) {
   };
 
   // this is called like at componentWillMount and componentWillUpdate equally
-  // simulates a synchronous useEffect, as a replacement for calculateData()
-  // if prevDeps or deps are not set shallowEqualArray always returns false
+  // in order to support render calls with synchronous data from the reactive computation
+  // if prevDeps or deps are not set areHookInputsEqual always returns false
+  // and the reactive functions is always called
   if (!areHookInputsEqual(deps, previousDeps.current)) {
     dispose();
 

--- a/packages/react-meteor-data/useTracker.js
+++ b/packages/react-meteor-data/useTracker.js
@@ -114,9 +114,8 @@ function useTracker(reactiveFn, deps) {
           // Additional cycles will follow the normal computation behavior.
           runReactiveFn();
         } else {
-          // Only run reactiveFn if the deps or are not falsy.
-          if (!deps || !refs.previousDeps) {
-            // Dispose early, if refs are falsy - we'll rebuild and run on the next render.
+          // If deps are falsy, stop computation and let next render handle reactiveFn.
+          if (!refs.previousDeps) {
             dispose();
           } else {
             runReactiveFn();

--- a/packages/react-meteor-data/withTracker.jsx
+++ b/packages/react-meteor-data/withTracker.jsx
@@ -7,7 +7,7 @@ export default function withTracker(options) {
     const { getMeteorData, pure = true } = expandedOptions;
 
     const WithTracker = forwardRef((props, ref) => {
-      const data = useTracker(() => getMeteorData(props) || {}, [props]);
+      const data = useTracker(() => getMeteorData(props) || {});
       return <Component ref={ref} {...props} {...data} />;
     });
 


### PR DESCRIPTION
- rewrite useTracker in order to stay fully consistent with current withTracker behavior
- compare deps in order to keep API consistency to React.useEffect()

fixes https://github.com/meteor/react-packages/pull/262